### PR TITLE
in python3 file is an instance of io.IOBase

### DIFF
--- a/src/python/golem/util/olp_objects.py
+++ b/src/python/golem/util/olp_objects.py
@@ -1,5 +1,7 @@
 # vim: ts=3:sw=3
 
+import io
+
 import golem
 
 from golem.util.config import GolemConfigError
@@ -648,7 +650,7 @@ class SUSYLesHouchesFile:
 	def __init__(self, *files):
 		self.blocks = {}
 		for f in files:
-			if isinstance(f, file):
+			if isinstance(f, io.IOBase):
 				self.load(f)
 			else:
 				the_file = open(f, "r")


### PR DESCRIPTION
Dear Authors,

There seems to be small bug in one of olp python modules. According to [this](https://stackoverflow.com/questions/36320953/isinstance-file-python-2-7-and-3-5) in `python3` a file is an instance of `io.IOBase`