### PR TITLE
Update avh_olo.wrap to specify the oneloop version explicitly

### DIFF
--- a/subprojects/avh_olo.wrap
+++ b/subprojects/avh_olo.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url=https://bitbucket.org/hameren/oneloop.git
-revision=head
+revision=v3.7.2
 depth=1
 patch_directory=avh_olo
 diff_files=avh_olo/create.py.patch


### PR DESCRIPTION
Update avh_olo.wrap to specify the oneloop version explicitly